### PR TITLE
Update logstash-filter-verifier version to 1.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM debian
+
+ENV VERIFIER_VERSION 1.6.0
+
 RUN apt-get update -y && apt-get install wget gnupg2 openjdk-11-jre apt-transport-https -y --no-install-recommends && apt-get clean && rm -rf /var/lib/apt/
 RUN wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add -
 RUN echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list
 RUN apt-get update -y && apt install logstash -y --no-install-recommends && apt-get clean && rm -rf /var/lib/apt/
-RUN wget https://github.com/magnusbaeck/logstash-filter-verifier/releases/download/1.5.1/logstash-filter-verifier_1.5.1_amd64.deb
-RUN dpkg -i logstash-filter-verifier_1.5.1_amd64.deb
+RUN wget -qO - https://github.com/magnusbaeck/logstash-filter-verifier/releases/download/${VERIFIER_VERSION}/logstash-filter-verifier_${VERIFIER_VERSION}_linux_amd64.tar.gz | tar xvzf - -C /usr/bin 
 RUN apt-get clean && rm -rf /var/lib/apt/
 COPY runtests.sh /
 CMD ["/runtests.sh"]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Building the container:
 
 Running the container
 
-``` docker run -d -v <FULL_PATH>/filters:/logstash/filters -v <FULL_PATH>/tests:/logstash/tests logstash-filter-verifier:latest ```
+``` docker run -d -v <FULL_PATH>/filters:/logstash -v <FULL_PATH>/tests:/logstash/tests logstash-filter-verifier:latest ```
 
 Results of tests will be in docker logs
 


### PR DESCRIPTION
And use tar.gz instead of deb since https://github.com/magnusbaeck/logstash-filter-verifier dropped debian packaging support from version 1.6.0+.

And minor readme file update.