### PR TITLE
Added changes tu use latest stable version of LFV and Logstash 8.X

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
 FROM debian
 
-ENV VERIFIER_VERSION 1.6.0
+ENV VERIFIER_VERSION 1.6.3
+ENV LOGSTASH_VERSION 8
 
+# Add unstable repo before updating, since openjdk-11-jre no longer exists in stable repo.
+RUN echo "deb http://deb.debian.org/debian unstable main non-free contrib" | tee -a /etc/apt/sources.list.d/java.list
 RUN apt-get update -y && apt-get install wget gnupg2 openjdk-11-jre apt-transport-https -y --no-install-recommends && apt-get clean && rm -rf /var/lib/apt/
 RUN wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add -
-RUN echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list
+RUN echo "deb https://artifacts.elastic.co/packages/$LOGSTASH_VERSION.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-${LOGSTASH_VERSION}.x.list
 RUN apt-get update -y && apt install logstash -y --no-install-recommends && apt-get clean && rm -rf /var/lib/apt/
 RUN wget -qO - https://github.com/magnusbaeck/logstash-filter-verifier/releases/download/${VERIFIER_VERSION}/logstash-filter-verifier_${VERIFIER_VERSION}_linux_amd64.tar.gz | tar xvzf - -C /usr/bin 
 RUN apt-get clean && rm -rf /var/lib/apt/


### PR DESCRIPTION
Updated the variable for the version of LFV to 1.6.3 which is the latest stable one; version 2.0 is still in BETA so we can wait it out. As for LOGSTASH, I added an ENV variable so the version could be changed in case someone wants to use other versions (my case at the moment), but left it as 8 since is the current one. 
I also had to add the unstable repo, since debian bookworm main repo doesn't have openjdk-11-jre, which is the java version compatible with most logstash versions.
I have tested the changes for both versions 7.17.y and 8.14.0 of logstash.